### PR TITLE
Add engine hub as a repo into the bom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,13 @@ allprojects {
     repositories {
         mavenCentral()
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
-        maven("https://maven.enginehub.org/repo")
+        maven {
+            url = uri("https://maven.enginehub.org/repo")
+            content {
+                includeGroup("org.enginehub")
+                includeGroup("com.sk89q")
+            }
+        }
         maven {
             url = uri("https://jitpack.io")
             content {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
+        maven("https://maven.enginehub.org/repo")
         maven {
             url = uri("https://jitpack.io")
             content {


### PR DESCRIPTION
## Overview
## Description
This PR adds the EngineHub Maven repo as a dependency to counteract complications of LineBus from WorldEdit in the future 

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
